### PR TITLE
[fix] refs #7 Djangoバージョンに脆弱性があったため2.1.5に変更

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aniso8601==3.0.2
 dj-database-url==0.5.0
 dj-static==0.0.6
-Django==2.1.2
+Django==2.1.5
 django-debug-toolbar==1.10.1
 django-environ==0.4.5
 django-filter==2.0.0


### PR DESCRIPTION
## 関連Issue
#7 
